### PR TITLE
feat: preserve the insertion order in the environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "clap-cargo",
  "color-eyre",
  "im",
+ "indexmap",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -1117,27 +1118,27 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5.47", features = ["derive"] }
 clap-cargo = "0.17.1"
 color-eyre = "0.6.5"
 im = "15.1.0"
+indexmap = "2.11.4"
 lalrpop-util = "0.22.2"
 logos = "0.15.1"
 miette = { version = "7.6.0", features = ["fancy"] }
@@ -23,4 +24,5 @@ thiserror = "2.0.16"
 lalrpop = "0.22.2"
 
 [features]
+type-check = []
 with-file-history = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use im::HashMap;
+use indexmap::IndexMap;
 use novo::{
     compile::{interpret_source_program, interpret_source_program_line},
     ir::{Context, Diagnostic, Output},
@@ -153,7 +154,7 @@ fn print_outputs(outputs: &[&Output]) -> Result<()> {
     for (x, v) in outputs
         .iter()
         .map(|o| (&o.ident, &o.value))
-        .collect::<std::collections::HashMap<_, _>>()
+        .collect::<IndexMap<_, _>>()
     {
         writeln!(&mut handle, "{x} = {v}").into_diagnostic()?;
     }


### PR DESCRIPTION
This PR preserves the order of insertions in the environment when displayed.